### PR TITLE
feat: implement relation scope for secret access grants

### DIFF
--- a/core/relation/key.go
+++ b/core/relation/key.go
@@ -4,6 +4,7 @@
 package relation
 
 import (
+	"sort"
 	"strings"
 
 	"github.com/juju/names/v6"
@@ -111,6 +112,7 @@ func (k Key) String() string {
 	for i, ei := range k {
 		endpoints[i] = ei.String()
 	}
+	sort.Strings(endpoints)
 	return strings.Join(endpoints, " ")
 }
 

--- a/domain/relation/modelmigration/import_test.go
+++ b/domain/relation/modelmigration/import_test.go
@@ -35,7 +35,7 @@ func (s *importSuite) TestImport(c *tc.C) {
 
 	model := s.expectImportRelations(c, map[int]corerelation.Key{
 		3: relationtesting.GenNewKey(c, "ubuntu:peer"),
-		7: relationtesting.GenNewKey(c, "ubuntu:juju-info ntp:juju-info"),
+		7: relationtesting.GenNewKey(c, "ntp:juju-info ubuntu:juju-info"),
 	}, charm.ScopeGlobal)
 
 	importOp := importOperation{
@@ -56,7 +56,7 @@ func (s *importSuite) TestImportRelationsWithContainerScope(c *tc.C) {
 
 	model := s.expectImportRelations(c, map[int]corerelation.Key{
 		3: relationtesting.GenNewKey(c, "ubuntu:peer"),
-		7: relationtesting.GenNewKey(c, "ubuntu:juju-info ntp:juju-info"),
+		7: relationtesting.GenNewKey(c, "ntp:juju-info ubuntu:juju-info"),
 	}, charm.ScopeContainer)
 
 	importOp := importOperation{

--- a/domain/schema/model/sql/0012-secret.sql
+++ b/domain/schema/model/sql/0012-secret.sql
@@ -309,13 +309,12 @@ SELECT
         WHEN sp.scope_type_id = 0 THEN scu.name
         WHEN sp.scope_type_id = 1 THEN sca.name
         WHEN sp.scope_type_id = 2 THEN m.uuid
-        -- TODO: we should be using the relation key here
-        WHEN sp.scope_type_id = 3 THEN sp.scope_uuid
+        WHEN sp.scope_type_id = 3 THEN scr.relation_key
     END) AS scope_id
 FROM secret_permission AS sp
 LEFT JOIN unit AS suu ON sp.subject_uuid = suu.uuid
 LEFT JOIN application AS sua ON sp.subject_uuid = sua.uuid
 LEFT JOIN unit AS scu ON sp.scope_uuid = scu.uuid
 LEFT JOIN application AS sca ON sp.scope_uuid = sca.uuid
-LEFT JOIN relation AS scr ON sp.scope_uuid = scr.uuid
+LEFT JOIN v_relation_key AS scr ON sp.scope_uuid = scr.relation_uuid
 JOIN model AS m;

--- a/domain/schema/model/sql/0024-relation.sql
+++ b/domain/schema/model/sql/0024-relation.sql
@@ -284,7 +284,15 @@ SELECT
 FROM relation_endpoint AS re
 JOIN application_endpoint AS ae ON re.endpoint_uuid = ae.uuid
 JOIN charm_relation AS cr ON ae.charm_relation_uuid = cr.uuid
-JOIN application AS a ON ae.application_uuid = a.uuid;
+JOIN application AS a ON ae.application_uuid = a.uuid
+ORDER BY application_name;
+
+CREATE VIEW v_relation_key AS
+SELECT
+    relation_uuid,
+    group_concat(concat(application_name, ':', endpoint_name), ' ') AS relation_key
+FROM v_relation_endpoint_identifier
+GROUP BY relation_uuid HAVING count(*) > 1;
 
 CREATE VIEW v_relation_status AS
 SELECT

--- a/domain/schema/model_schema_test.go
+++ b/domain/schema/model_schema_test.go
@@ -383,6 +383,7 @@ func (s *modelSchemaSuite) TestModelViews(c *tc.C) {
 		"v_port_range",
 		"v_relation_endpoint",
 		"v_relation_endpoint_identifier",
+		"v_relation_key",
 		"v_relation_status",
 		"v_resource",
 		"v_revision_updater_application_unit",

--- a/domain/secret/service/exportimport.go
+++ b/domain/secret/service/exportimport.go
@@ -194,7 +194,7 @@ func (s *SecretService) ImportSecrets(ctx context.Context, modelSecrets *SecretE
 		//}
 
 		for _, access := range modelSecrets.Access[md.URI.ID] {
-			p := grantParams(SecretAccessParams{
+			p, err := grantParams(SecretAccessParams{
 				Scope: SecretAccessScope{
 					Kind: access.Scope.Kind,
 					ID:   access.Scope.ID,
@@ -205,6 +205,9 @@ func (s *SecretService) ImportSecrets(ctx context.Context, modelSecrets *SecretE
 				},
 				Role: access.Role,
 			})
+			if err != nil {
+				return errors.Capture(err)
+			}
 			if err := s.secretState.GrantAccess(ctx, md.URI, p); err != nil {
 				return errors.Errorf("saving secret access for %s-%s for secret %q: %w",
 					access.Subject.Kind, access.Subject.ID, md.URI.ID, err)

--- a/domain/secret/service/exportimport_test.go
+++ b/domain/secret/service/exportimport_test.go
@@ -236,7 +236,7 @@ func (s *serviceSuite) TestImportSecrets(c *tc.C) {
 	//})
 	s.state.EXPECT().GrantAccess(gomock.Any(), uri, domainsecret.GrantParams{
 		ScopeTypeID:   3,
-		ScopeID:       "wordpress:db mysql:server",
+		ScopeID:       "mysql:server wordpress:db",
 		SubjectTypeID: 0,
 		SubjectID:     "wordpress/0",
 		RoleID:        1,

--- a/domain/secret/service/service_test.go
+++ b/domain/secret/service/service_test.go
@@ -1183,7 +1183,7 @@ func (s *serviceSuite) TestGrantSecretRelationScope(c *tc.C) {
 	}).Return("manage", nil)
 	s.state.EXPECT().GrantAccess(gomock.Any(), uri, domainsecret.GrantParams{
 		ScopeTypeID:   domainsecret.ScopeRelation,
-		ScopeID:       "mysql:db mediawiki:db",
+		ScopeID:       "mediawiki:db mysql:db",
 		SubjectTypeID: domainsecret.SubjectApplication,
 		SubjectID:     "mysql",
 		RoleID:        domainsecret.RoleView,

--- a/internal/migration/precheck_test.go
+++ b/internal/migration/precheck_test.go
@@ -589,7 +589,7 @@ func (s *SourcePrecheckSuite) TestSubordinatesNotYetInScope(c *tc.C) {
 
 	//backend := newHappyBackend()
 	err := s.sourcePrecheck(c)
-	c.Assert(err, tc.ErrorMatches, `unit bar/1 hasn't joined relation "foo:db bar:db" yet`)
+	c.Assert(err, tc.ErrorMatches, `unit bar/1 hasn't joined relation "bar:db foo:db" yet`)
 }
 
 func (s *SourcePrecheckSuite) TestCrossModelUnitsNotYetInScope(c *tc.C) {


### PR DESCRIPTION
This PR implements a secrets TODO which is to use a join to the relation table to realise relation scoped access grants. When the work was first done, relations didn't exist.

The access scopes are stored using the natural key so a new relations view `v_relation_key` is added to expose the relation keys per relation. The key parts are ordered by app name for repeatability.

As a drive by, fix some nil contexts in the secret hook commands resulting from a mistake in merging 3.6.

## QA steps

```
juju deploy juju-qa-dummy-source
juju deploy juju-qa-dummy-sink
juju relate dummy-source dummy-sink
juju exec -u dummy-source/0 -- secret-add foo=bar 
<uri>
juju exec -u dummy-source/0 -- secret-grant -r 1 <uri>
juju exec -u dummy-sink/0 -- secret-get <uri>
foo: bar
juju exec -u dummy-source/0 -- secret-revoke -r 1 <uri>
$ juju exec -u dummy-sink/0 -- secret-get <uri>        
ERROR "dummy-sink/0" is not allowed to read this secret
```

## Links

**Jira card:** [JUJU-8700](https://warthogs.atlassian.net/browse/JUJU-8700)

[JUJU-8700]: https://warthogs.atlassian.net/browse/JUJU-8700?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ